### PR TITLE
Correct read limit based on differet GRIB version

### DIFF
--- a/gdal/frmts/grib/degrib/g2clib/seekgb.c
+++ b/gdal/frmts/grib/degrib/g2clib/seekgb.c
@@ -53,7 +53,7 @@ void seekgb(FILE *lugb,g2int iseek,g2int mseek,g2int *lskip,g2int *lgrib)
 
         /* ret= */ fseek(lugb,ipos,SEEK_SET);
         nread=(int)fread(cbuf,sizeof(unsigned char),mseek,lugb);
-        lim=nread-8;
+        lim = nread - (vers == 2 ? 16 : 8);
 
 //  LOOK FOR 'GRIB...' IN PARTIAL SECTION
 


### PR DESCRIPTION
 version 1 is 8 bytes (https://www.nco.ncep.noaa.gov/pmb/docs/on388/section0.html)
- version 2 is 16 bytes (https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_sect0.shtml)

<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
there is a read limit defined here(expecting the packet header to be max. 8 byte):
https://github.com/OSGeo/gdal/blob/master/gdal/frmts/grib/degrib/g2clib/seekgb.c#L56
which is fine for version 1 packets(i have no idea what if "packet" is a good name), their layout seems to be MMMM LLL V (Magic, Length, Version)
but version 2 packets are longer (16 bytes), this results in reading out of bounds here:
https://github.com/OSGeo/gdal/blob/master/gdal/frmts/grib/degrib/g2clib/seekgb.c#L66
(it reads 4*8 bits at offset 12*8 bits)

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
